### PR TITLE
Convert error

### DIFF
--- a/src/GraphSignals.jl
+++ b/src/GraphSignals.jl
@@ -1,6 +1,6 @@
 module GraphSignals
 
-using LinearAlgebra: issymmetric, diag, diagm
+using LinearAlgebra: issymmetric, diag, diagm, Transpose
 
 using FillArrays
 using GraphLaplacians

--- a/src/featuredgraph.jl
+++ b/src/featuredgraph.jl
@@ -126,10 +126,6 @@ function FeaturedGraph(graph::T, nf::S; directed::Symbol=:auto) where {T<:Abstra
     E = ne(graph)
     # check_num_node(N, nf)
 
-    if isa(nf, CuArray)
-        graph = convert(typeof(nf), graph)  # ensure graph has the same type as nf, especially X::CuArray
-    end
-
     ef = Fill(z, (0, E))
     gf = Fill(z, 0)
     mask = Fill(z, (N, N))

--- a/src/featuredgraph.jl
+++ b/src/featuredgraph.jl
@@ -126,11 +126,15 @@ function FeaturedGraph(graph::T, nf::S; directed::Symbol=:auto) where {T<:Abstra
     E = ne(graph)
     # check_num_node(N, nf)
 
+    graph = convert(S, graph)
     ef = Fill(z, (0, E))
     gf = Fill(z, 0)
     mask = Fill(z, (N, N))
     FeaturedGraph(graph, nf, ef, gf, mask, :adjm, dir)
 end
+
+FeaturedGraph(graph::T, nf::Transpose{S,R}, args...; kwargs...) where {T<:AbstractMatrix,S,R<:AbstractMatrix} =
+    FeaturedGraph(graph, R(nf), args...; kwargs...)
 
 function FeaturedGraph(graph, nf::S, ef::R, gf::Q; directed::Symbol=:auto) where {S<:AbstractMatrix,R<:AbstractMatrix,Q<:AbstractVector}
     @assert directed ∈ DIRECTEDS "directed must be one of :auto, :directed and :undirected"

--- a/src/featuredgraph.jl
+++ b/src/featuredgraph.jl
@@ -126,7 +126,10 @@ function FeaturedGraph(graph::T, nf::S; directed::Symbol=:auto) where {T<:Abstra
     E = ne(graph)
     # check_num_node(N, nf)
 
-    graph = convert(typeof(nf), graph)
+    if isa(nf, CuArray)
+        graph = convert(typeof(nf), graph)  # ensure graph has the same type as nf, especially X::CuArray
+    end
+
     ef = Fill(z, (0, E))
     gf = Fill(z, 0)
     mask = Fill(z, (N, N))

--- a/test/featuredgraph.jl
+++ b/test/featuredgraph.jl
@@ -55,6 +55,18 @@ gf = rand(7)
     @test global_feature(fg) == zeros(0)
     @test mask(fg) == zeros(N, N)
 
+    # Test with transposed features
+    fg = FeaturedGraph(adj, transpose(nf))
+    @test has_graph(fg)
+    @test has_node_feature(fg)
+    @test has_edge_feature(fg) == false
+    @test has_global_feature(fg) == false
+    @test graph(fg) == adj
+    @test node_feature(fg) == transpose(nf)
+    @test edge_feature(fg) == Fill(0., (0, E))
+    @test global_feature(fg) == zeros(0)
+    @test mask(fg) == zeros(N, N)
+
 
     fg = FeaturedGraph(ug, nf)
     @test has_graph(fg)


### PR DESCRIPTION
This PR is to let FeaturedGraph accept ~~graph~~ features matrices that were transposed before.

Specifically, this is to close https://github.com/yuehhua/GeometricFlux.jl/issues/110 .
This is bound to https://github.com/yuehhua/GeometricFlux.jl/pull/128

However, this has to be merged before GeometricFlux' one.


I removed one line, that made my PR on GeometricFlux work, and didn't break any test locally. I couldn't do the same thing as in https://github.com/yuehhua/GeometricFlux.jl/pull/128 because CUDA is not an explicit dependancy (so I couldn't put a condition on `CuArray` type).
 
I understand the content of this PR is completely debatable, feel free to discuss about it.

EDIT: I had mixed up graph and features matrices