### PR TITLE
Integrate positional encoding to FeaturedGraph

### DIFF
--- a/src/GraphSignals.jl
+++ b/src/GraphSignals.jl
@@ -67,9 +67,11 @@ export
     # neighbor_graphs
     kneighbors_graph
 
+include("utils.jl")
 include("graph.jl")
 include("linalg.jl")
 include("sparsematrix.jl")
+
 include("sparsegraph.jl")
 include("graphdomains.jl")
 include("featuredgraph.jl")

--- a/src/featuredgraph.jl
+++ b/src/featuredgraph.jl
@@ -82,14 +82,14 @@ mutable struct FeaturedGraph{T,Tn,Te,Tg,Tp} <: AbstractFeaturedGraph
 
     function FeaturedGraph(graph::SparseGraph, nf::Tn, ef::Te, gf::Tg, pf::Tp,
                            mt::Symbol) where {Tn<:AbstractArray,Te<:AbstractArray,Tg<:AbstractArray,Tp<:AbstractGraphDomain}
-        errmsg = "matrix_type must be one of $(join(_string.(MATRIX_TYPES), ", ", " or "))"
-        mt ∈ MATRIX_TYPES || throw(ArgumentError(errmsg))
+        check_matrix_type(mt)
+        check_features(graph, nf, ef, pf)
         new{typeof(graph),Tn,Te,Tg,Tp}(graph, nf, ef, gf, pf, mt)
     end
     function FeaturedGraph{T,Tn,Te,Tg,Tp}(graph, nf, ef, gf, pf, mt
             ) where {T,Tn<:AbstractArray,Te<:AbstractArray,Tg<:AbstractArray,Tp<:AbstractGraphDomain}
-        errmsg = "matrix_type must be one of $(join(_string.(MATRIX_TYPES), ", ", " or "))"
-        mt ∈ MATRIX_TYPES || throw(ArgumentError(errmsg))
+        check_matrix_type(mt)
+        check_features(graph, nf, ef, pf)
         new{T,Tn,Te,Tg,Tp}(T(graph), Tn(nf), Te(ef), Tg(gf), Tp(pf), mt)
     end
 end
@@ -196,7 +196,12 @@ check_num_edges(graph_ne::Real, feat) = check_num_edges(graph_ne, size(feat, 2))
 check_num_nodes(g, feat) = check_num_nodes(nv(g), feat)
 check_num_edges(g, feat) = check_num_edges(ne(g), feat)
 
-function check_precondition(graph, nf, ef, pf)
+function check_matrix_type(mt::Symbol)
+    errmsg = "matrix_type must be one of $(join(_string.(MATRIX_TYPES), ", ", " or "))"
+    mt ∈ MATRIX_TYPES || throw(ArgumentError(errmsg))
+end
+
+function check_features(graph, nf, ef, pf)
     check_num_edges(ne(graph), ef)
     check_num_nodes(nv(graph), nf)
     check_num_nodes(nv(graph), pf)

--- a/src/graphdomains.jl
+++ b/src/graphdomains.jl
@@ -7,7 +7,7 @@ domain(::NullDomain) = nothing
 positional_feature(::NullDomain) = nothing
 has_positional_feature(::NullDomain) = false
 pf_dims_repr(::NullDomain) = 0
-check_num_nodes(graph_nv::Real, ::NullDomain) = check_num_nodes(graph_nv, 0)
+check_num_nodes(graph_nv::Real, ::NullDomain) = nothing
 
 
 struct NodeDomain{T} <: AbstractGraphDomain

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,40 @@
+"""
+    generate_coordinates(A, with_batch=false)
+
+Returns coordinates for tensor `A`.
+
+# Arguments
+
+- `A::AbstractArray`: The tensor to reference to.
+- `with_batch::Bool`: Whether to consider last dimension as batch. If `with_batch=true`,
+the last dimension is not consider as a component of coordinates.
+
+# Usage
+
+```jldoctest
+julia> using GraphSignals
+
+julia> A = rand(3, 4, 5);
+
+julia> coord = GraphSignals.generate_coordinates(A);
+
+julia> size(coord)
+(3, 3, 4, 5)
+
+julia> coord = GraphSignals.generate_coordinates(A, with_batch=true);
+
+julia> size(coord)
+(2, 3, 4)
+```
+"""
+function generate_coordinates(A::AbstractArray; with_batch::Bool=false)
+    dims = with_batch ? size(A)[1:end-1] : size(A)
+    N = length(dims)
+    colons = ntuple(i -> Colon(), N)
+    coord = similar(A, N, dims...)
+    for i in 1:N
+        ones = ntuple(x -> 1, i-1)
+        coord[i, colons...] .= reshape(1:dims[i], ones..., :)
+    end
+    return coord
+end

--- a/test/featuredgraph.jl
+++ b/test/featuredgraph.jl
@@ -87,20 +87,25 @@
                  1 0 1 1;
                  0 1 0 1;
                  1 1 1 0]
-        fg = FeaturedGraph(adjm1; nf=nf, ef=ef, gf=gf)
+        fg = FeaturedGraph(adjm1; nf=nf, ef=ef, gf=gf, pf=pf)
         fg.graph.S .= adjm2
         @test fg.graph.S == adjm2
         @test_throws DimensionMismatch fg.graph = [0 1; 0 1]
 
         nf_ = rand(10, V)
         fg.nf = nf_
-        @test fg.nf == nf_
+        @test node_feature(fg) == nf_
         @test_throws DimensionMismatch fg.nf = rand(10, 11)
 
         ef_ = rand(10, E)
         fg.ef = ef_
-        @test fg.ef == ef_
+        @test edge_feature(fg) == ef_
         @test_throws DimensionMismatch fg.ef = rand(10, 11)
+
+        pf_ = rand(10, V)
+        fg.pf = pf_
+        @test positional_feature(fg) == pf_
+        @test_throws DimensionMismatch fg.pf = rand(10, 11)
     end
 
     @testset "graph properties" begin
@@ -114,6 +119,16 @@
         @test edges(fg) isa GraphSignals.EdgeIter
         @test neighbors(fg) == [2, 3, 4, 1, 3, 1, 2, 4, 1, 3]
         @test incident_edges(fg) == fg |> graph |> GraphSignals.edgevals
+    end
+
+    @testset "generate coordinates" begin
+        adjm = [0 1 1 1;
+                1 0 1 0;
+                1 1 0 1;
+                1 0 1 0]
+
+        fg = FeaturedGraph(adjm; nf=nf, pf=:auto)
+        @test size(positional_feature(fg)) == (1, V)
     end
 
     @testset "random subgraph" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ CUDA.allowscalar(false)
 include("test_utils.jl")
 
 tests = [
+    "utils",
     "graph",
     "linalg",
     "sparsegraph",

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,11 @@
+@testset "utils" begin
+    dims = (3, 4, 5)
+    N = length(dims)
+
+    A = rand(dims...)
+    coord = GraphSignals.generate_coordinates(A)
+    @test size(coord) == (N, dims...)
+
+    coord = GraphSignals.generate_coordinates(A, with_batch=true)
+    @test size(coord) == (N-1, dims[1:end-1]...)
+end


### PR DESCRIPTION
1. [x] `FeaturedGraph` considering grid condition and generating positional encoding automatically by kwargs `pf=:auto`
2. [x] Assign positional encoding to `FeaturedGraph` manually by kwargs `pf=PE`
3. [x] `FeaturedGraph` without positional encoding by  kwargs `pf=nothing`