### PR TITLE
Don't collect `qr.Q`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GraphSignals"
 uuid = "3ebe565e-a4b5-49c6-aed2-300248c3a9c1"
 authors = ["Yueh-Hua Tu <a504082002@gmail.com>"]
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -11,7 +11,7 @@ function orthogonal_random_features(::Type{T}, nvertex::Int, dims::Vararg{Int}) 
     N = length(dims) + 2
     orf = Array{T,N}(undef, nvertex, nvertex, dims...)
     for cidx in CartesianIndices(dims)
-        G = randn(nvertex, nvertex)
+        G = randn(T, nvertex, nvertex)
         A = qr(G)
         copyto!(view(orf, :, :, cidx), A.Q)
     end

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -13,7 +13,7 @@ function orthogonal_random_features(::Type{T}, nvertex::Int, dims::Vararg{Int}) 
     for cidx in CartesianIndices(dims)
         G = randn(nvertex, nvertex)
         A = qr(G)
-        orf[:, :, cidx] .= collect(A.Q)
+        copyto!(view(orf, :, :, cidx), A.Q)
     end
     return orf
 end


### PR DESCRIPTION
The `Q` is not really a usual matrix, and `collect`ing it is slow anyways. It will stop to work after https://github.com/JuliaLang/julia/pull/46196 is merged. There exists a `copyto!` method that should be relatively fast in the given context, since the `view` returns a strided matrix. If eltype promotion might be an issue, then perhaps replacing `collect` by `Matrix` is the way to go.