### PR TITLE
Drop Adapt deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Yueh-Hua Tu <a504082002@gmail.com>"]
 version = "0.8.4"
 
 [deps]
-Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -21,7 +20,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Adapt = "3"
 CUDA = "3"
 ChainRulesCore = "1"
 Distances = "0.10"

--- a/src/GraphSignals.jl
+++ b/src/GraphSignals.jl
@@ -3,7 +3,7 @@ module GraphSignals
 using LinearAlgebra
 using SparseArrays
 
-using CUDA, CUDA.CUSPARSE, Adapt
+using CUDA, CUDA.CUSPARSE
 using ChainRulesCore
 using ChainRulesCore: @non_differentiable
 using Distances

--- a/src/graphdomain.jl
+++ b/src/graphdomain.jl
@@ -14,10 +14,10 @@ struct NodeDomain{T} <: AbstractGraphDomain
     domain::T
 end
 
+@functor NodeDomain
+
 NodeDomain(::Nothing) = NullDomain()
 NodeDomain(d::AbstractGraphDomain) = d
-
-Adapt.adapt_structure(to, d::NodeDomain) = NodeDomain(Adapt.adapt(to, d.domain))
 
 domain(d::NodeDomain) = d.domain
 positional_feature(d::NodeDomain) = d.domain

--- a/src/graphsignal.jl
+++ b/src/graphsignal.jl
@@ -24,11 +24,11 @@ struct NodeSignal{T} <: AbstractGraphSignal
     signal::T
 end
 
+@functor NodeSignal
+
 NodeSignal(::Nothing) = NullGraphSignal()
 NodeSignal(::NullGraphSignal) = NullGraphSignal()
 NodeSignal(s::NodeSignal) = s
-
-Adapt.adapt_structure(to, s::NodeSignal) = NodeSignal(Adapt.adapt(to, s.signal))
 
 signal(s::NodeSignal) = s.signal
 node_feature(s::NodeSignal) = s.signal
@@ -41,11 +41,11 @@ struct EdgeSignal{T} <: AbstractGraphSignal
     signal::T
 end
 
+@functor EdgeSignal
+
 EdgeSignal(::Nothing) = NullGraphSignal()
 EdgeSignal(::NullGraphSignal) = NullGraphSignal()
 EdgeSignal(s::EdgeSignal) = s
-
-Adapt.adapt_structure(to, s::EdgeSignal) = EdgeSignal(Adapt.adapt(to, s.signal))
 
 signal(s::EdgeSignal) = s.signal
 edge_feature(s::EdgeSignal) = s.signal
@@ -58,11 +58,11 @@ struct GlobalSignal{T} <: AbstractGraphSignal
     signal::T
 end
 
+@functor GlobalSignal
+
 GlobalSignal(::Nothing) = NullGraphSignal()
 GlobalSignal(::NullGraphSignal) = NullGraphSignal()
 GlobalSignal(s::GlobalSignal) = s
-
-Adapt.adapt_structure(to, s::GlobalSignal) = GlobalSignal(Adapt.adapt(to, s.signal))
 
 signal(s::GlobalSignal) = s.signal
 global_feature(s::GlobalSignal) = s.signal


### PR DESCRIPTION
After correcting the wrong dispatching issue from FluxML/Flux.jl#2033, Adapt dependency is no more needed.